### PR TITLE
Fix `map` wrapper

### DIFF
--- a/changelog/+wrapper.fixed.md
+++ b/changelog/+wrapper.fixed.md
@@ -1,0 +1,1 @@
+Fixed map wrapper crash caused by not converting to master path

--- a/src/saltext/formula/modules/map.py
+++ b/src/saltext/formula/modules/map.py
@@ -211,7 +211,8 @@ def data(
         formula_config["map_jinja"] = map_config
         if map_config["post_map"] is not False:
             # Just rendering the template propagates its changes to mapdata.
-            # We don't care about its output.
+            # We don't care about its output, so we don't need to ensure
+            # the path is converted in Salt-SSH either by calling _get_template.
             __salt__["cp.get_template"](
                 f"salt://{tplroot}/{map_config['post_map']}",
                 "",
@@ -327,9 +328,8 @@ def stack(
             for param_dir in parameter_dirs:
                 for yaml_name in all_yaml_names:
                     yaml_path = Path(param_dir, yaml_dirname, yaml_name)
-                    yaml_cached = __salt__["cp.get_template"](
-                        f"salt://{yaml_path}",
-                        "",
+                    yaml_cached = _get_template(
+                        yaml_path,
                         tpldir=tpldir,
                         tplroot=tplroot,
                         mapdata=res["values"],
@@ -423,3 +423,11 @@ def _render_matcher(matcher, config_get_strategy=None):
         )
 
     return parsed
+
+
+def _get_template(path, **kwargs):
+    return __salt__["cp.get_template"](
+        f"salt://{path}",
+        "",
+        **kwargs,
+    )

--- a/src/saltext/formula/wrapper/map.py
+++ b/src/saltext/formula/wrapper/map.py
@@ -2,6 +2,9 @@
 SSH wrapper for the :py:mod:`map <saltext.formula.modules.map>` execution module.
 
 See there for documentation.
+
+.. important::
+    This wrapper requires the ``cp`` wrapper introduced in Salt 3007.0.
 """
 
 import logging
@@ -26,3 +29,14 @@ data = namespaced_function(data, globals())
 stack = namespaced_function(stack, globals())
 _render_matcher = namespaced_function(_render_matcher, globals())
 _render_matchers = namespaced_function(_render_matchers, globals())
+
+
+def _get_template(path, **kwargs):
+    res = __salt__["cp.get_template"](
+        f"salt://{path}",
+        "",
+        **kwargs,
+    )
+    if not res:
+        return res
+    return __salt__["cp.convert_cache_path"](res)

--- a/tests/integration/wrapper/test_map.py
+++ b/tests/integration/wrapper/test_map.py
@@ -1,0 +1,193 @@
+import contextlib
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "salt.version",
+    minversion="3007",
+    reason="relies on cp.get_template wrapper, only present in Salt 3007.0+",
+)
+
+pytestmark = [
+    pytest.mark.skip_unless_on_linux(reason="Salt-SSH is not available for Windows"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ssh_opts(master):
+    ssh_opts = {
+        "ssh_minion_opts": {
+            "tplroot": {
+                "data_source": "opts",
+                "opts": True,
+            },
+            "roles": ["db", "db_master"],
+        },
+    }
+    with pytest.helpers.temp_file(
+        "ssh_opts.conf",
+        json.dumps(ssh_opts),
+        Path(master.config_dir) / "master.d",
+    ):
+        yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def formula_setup(master):
+    param_files = {
+        "defaults.yaml": (
+            """\
+            values:
+              data_source: defaults_yaml
+              defaults_yaml: true
+            """
+        ),
+        "roles/db.yaml.jinja": (
+            """\
+            values:
+              data_source: db_yaml
+              db_yaml: true
+              previous: {{ mapdata["data_source"] }}
+            """
+        ),
+        "map_jinja.yaml": (
+            """\
+            values:
+              sources:
+                - defaults.yaml
+                - Y:G@os
+                - C@{{ tplroot }}
+                - Y:C@roles
+                - Y:G@id
+            """
+        ),
+    }
+    with contextlib.ExitStack() as stack:
+        for path, contents in param_files.items():
+            stack.enter_context(
+                master.state_tree.base.temp_file(f"tplroot/parameters/{path}", contents)
+            )
+        yield
+
+
+@pytest.fixture
+def post_map(master):
+    contents = """\
+        {%- do mapdata.update({"data_source": "post_map", "post_map": true}) %}
+        """
+    with master.state_tree.base.temp_file("tplroot/post-map.jinja", contents):
+        yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _cp_wrapper(master, salt_ssh_cli):
+    # The wrapper returns minion paths.
+    # Since we're testing on the same node, the path would exist
+    # when running in the test suite, but not when running for real.
+    # This wrapper deletes the minion cache path to ensure we validate
+    # the map.data wrapper converts it to the master cache path.
+    # We cannot override single functions of inbuilt modules, so we need
+    # to provide all functions our wrapper is going to use.
+    contents = """\
+        from pathlib import Path
+
+        import salt.utils.context
+        from salt.client.ssh.wrapper import cp
+
+        __virtualname__ = "cp"
+
+
+        def __virtual__():
+            return __virtualname__
+
+
+        def _call_cp(func, args, kwargs):
+            with salt.utils.context.func_globals_inject(
+                func,
+                __opts__=__opts__,
+                __salt__=__salt__,
+                __grains__=__grains__,
+                __pillar__=__pillar__,
+                __context__=__context__,
+            ):
+                return func(*args, **kwargs)
+
+
+        def get_template(*args, **kwargs):
+            res = _call_cp(cp.get_template, args, kwargs)
+            if res:
+                Path(res).unlink()
+            return res
+
+
+        def convert_cache_path(*args, **kwargs):
+            return _call_cp(cp.convert_cache_path, args, kwargs)
+
+
+        def is_wrapped_correctly():
+            return True
+        """
+    with master.state_tree.base.temp_file("_wrapper/cp.py", contents):
+        res = master.salt_run_cli().run("saltutil.sync_all")
+        assert res.returncode == 0
+        assert "wrapper.cp" in res.data["wrapper"]
+        res = salt_ssh_cli.run("cp.is_wrapped_correctly")
+        assert res.returncode == 0
+        assert res.data is True
+        yield
+
+
+def test_data(salt_ssh_cli):
+    res = salt_ssh_cli.run("map.data", "tplroot/foo/bar")
+    assert res.returncode == 0
+    _assert_data(res.data, "db_yaml")
+
+
+@pytest.mark.usefixtures("post_map")
+def test_data_post_map(salt_ssh_cli):
+    res = salt_ssh_cli.run("map.data", "tplroot/foo/bar")
+    assert res.returncode == 0
+    _assert_data(res.data, "post_map", "post_map")
+
+
+@pytest.fixture
+def _state_data(master):
+    contents = """\
+        foo:
+          test.show_notification:
+            - text: '{{ salt["map.data"](tpldir) | json }}'
+        """
+    with master.state_tree.base.temp_file("tplroot/_mapdata.sls", contents):
+        yield "tplroot._mapdata"
+
+
+def test_data_in_template(salt_ssh_cli, _state_data):
+    res = salt_ssh_cli.run("state.show_sls", _state_data)
+    assert res.returncode == 0
+    assert res.data
+    _assert_data(res.data, "db_yaml", show_sls=True)
+
+
+@pytest.mark.usefixtures("post_map")
+def test_data_in_template_with_post_map(salt_ssh_cli, _state_data):
+    res = salt_ssh_cli.run("state.show_sls", _state_data)
+    assert res.returncode == 0
+    assert res.data
+    _assert_data(res.data, "post_map", "post_map", show_sls=True)
+
+
+def _assert_data(data, source, *extra_keys, show_sls=False):
+    if show_sls:
+        for param in data["foo"]["test"]:
+            if "text" not in param:
+                continue
+            data = json.loads(param["text"])
+            break
+        else:
+            raise RuntimeError("Failed parsing state.show_sls output")
+    assert data["data_source"] == source
+    assert data["previous"] == "opts"
+    for param in ("defaults_yaml", "db_yaml", "opts", *extra_keys):
+        assert param in data


### PR DESCRIPTION
### What does this PR do?
The `cp.get_template` wrapper module (only found in 3007.0+) returns the remote minion's cache path, not the local one, which we're expecting.

Since the wrapper is a direct copy of the module, just account for it in the execution module. This could be handled better, but it's a start.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
`FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/.root_abcdef_salt/running_data/var/cache/salt/minion/extrn_files/base/parameters/map_jinja.yaml'`

### New Behavior
works

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes