### PR TITLE
Fix CLI invocation of map module funcs

### DIFF
--- a/changelog/+cli.fixed.md
+++ b/changelog/+cli.fixed.md
@@ -1,0 +1,1 @@
+Fixed CLI invocation of map.data/map.stack/map.tofs

--- a/src/saltext/formula/modules/map.py
+++ b/src/saltext/formula/modules/map.py
@@ -64,7 +64,6 @@ def __virtual__():
 def data(
     tpldir,
     sources=None,
-    *,
     parameter_dirs=None,
     config_get_strategy=None,
     default_merge_strategy=None,
@@ -237,7 +236,6 @@ def data(
 def stack(
     tpldir,
     sources,
-    *,
     parameter_dirs=None,
     default_values=None,
     default_merge_strategy=None,
@@ -356,7 +354,6 @@ def stack(
 def tofs(
     tpldir,
     source_files,
-    *,
     lookup=None,
     default_matchers=None,
     use_subpath=False,

--- a/src/saltext/formula/wrapper/map.py
+++ b/src/saltext/formula/wrapper/map.py
@@ -13,9 +13,9 @@ from salt.utils.functools import namespaced_function
 
 from saltext.formula.modules.map import _render_matcher as _render_matcher_base
 from saltext.formula.modules.map import _render_matchers as _render_matchers_base
-from saltext.formula.modules.map import data as data_base
-from saltext.formula.modules.map import stack as stack_base
-from saltext.formula.modules.map import tofs as tofs_base
+from saltext.formula.modules.map import data
+from saltext.formula.modules.map import stack
+from saltext.formula.modules.map import tofs
 
 log = logging.getLogger(__name__)
 
@@ -26,24 +26,24 @@ def __virtual__():
     return __virtualname__
 
 
-data = namespaced_function(data_base, globals())
-stack = namespaced_function(stack_base, globals())
-tofs = namespaced_function(tofs_base, globals())
+data = namespaced_function(data, globals())
+stack = namespaced_function(stack, globals())
+tofs = namespaced_function(tofs, globals())
 _render_matcher = namespaced_function(_render_matcher_base, globals())
 _render_matchers = namespaced_function(_render_matchers_base, globals())
 
 
 for func, base in (
-    (data, data_base),
-    (stack, stack_base),
-    (tofs, tofs_base),
     (_render_matcher, _render_matcher_base),
     (_render_matchers, _render_matchers_base),
 ):
     # namespaced_function does not initialize keyword-only argument defaults,
     # making them required arguments.
+    # The module functions (data/stack/tofs) cannot use them since
+    # Salt does not recognize them when using the CLI to call them.
     # Starting with Python 3.13, it's possible to pass `kwdefaults` to types.FunctionType
-    func.__kwdefaults__ = base.__kwdefaults__.copy()
+    if getattr(base, "__kwdefaults__", None) is not None:
+        func.__kwdefaults__ = base.__kwdefaults__.copy()
 
 
 def _get_template(path, **kwargs):


### PR DESCRIPTION
### What does this PR do?
Fix CLI invocation of `map` module funcs. This is borked because Salt (`salt.utils.args.get_function_argspec`) does not account for kwarg-only arguments.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
`The following keyword arguments are not valid:`

### New Behavior
works

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes