### PR TITLE
Introduce chains

### DIFF
--- a/changelog/+chains.added.md
+++ b/changelog/+chains.added.md
@@ -1,0 +1,1 @@
+Added matcher chains

--- a/changelog/+matchers.added.md
+++ b/changelog/+matchers.added.md
@@ -1,0 +1,1 @@
+Added M/P/U matchers

--- a/docs/topics/tofs.md
+++ b/docs/topics/tofs.md
@@ -39,7 +39,7 @@ Manage nginx.conf:
 ## Differences to `libtofs.jinja`
 * By default, includes the query in file paths (`files/os_family/Debian` instead of `files/Debian`). This can be disabled via the `include_query` parameter.
 * Reads `tofs` configuration from all Mapstack sources (including YAML). Previously, this configuration could only be set in pillars/grains/opts.
-* Accepts matcher definitions for file paths in the [same style as Mapstack](matcher-def-target) (excluding `Y@`).
+* Accepts matcher definitions, including chains, for file paths in the [same style as Mapstack](matcher-def-target) (`Y!` prefix is disallowed).
 
 ## Reference
 This overview is currently very basic. For details, see the [original description][tofs-pattern].

--- a/src/saltext/formula/modules/map.py
+++ b/src/saltext/formula/modules/map.py
@@ -4,10 +4,18 @@ Provide helpers to render layered formula configuration.
 This is heavily based on the excellent work done in the `template-formula <https://github.com/saltstack-formulas/template-formula>`_.
 """
 
+import itertools
 import logging
+import pickle
 from collections import ChainMap
+from collections.abc import Iterable
+from collections.abc import Sequence
 from itertools import chain
 from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Union
 
 import salt.loader
 import salt.utils.yaml
@@ -15,13 +23,20 @@ from salt.utils.data import traverse_dict_and_list as traverse
 from salt.utils.dictupdate import merge
 from salt.utils.immutabletypes import freeze
 
+try:
+    from types import EllipsisType
+except ImportError:
+    # Python <3.10
+    EllipsisType = type(Ellipsis)  # type: ignore
+
+
 DEFAULT_MATCHERS = (
-    "Y:G@osarch",
-    "Y:G@os_family",
-    "Y:G@os",
-    "Y:G@osfinger",
+    "Y!G@osarch",
+    "Y!G@os_family",
+    "Y!G@os",
+    "Y!G@osfinger",
     "C@{tplroot}",
-    "Y:G@id",
+    "Y!G@id",
 )
 
 DEFAULT_PARAM_DIRS_MAPDATA = ("{tplroot}/parameters",)
@@ -49,8 +64,6 @@ QUERY_MAP = freeze(
 
 CKEY = "_formula_mapdata"
 
-# Use an object instance to track whether a query was successful or not
-UNSET = frozenset()
 
 log = logging.getLogger(__name__)
 
@@ -71,6 +84,7 @@ def data(
     post_map="post-map.jinja",
     post_map_template="jinja",
     cache=True,
+    custom_data=None,
 ):
     """
     Render formula configuration.
@@ -99,13 +113,13 @@ def data(
 
         .. code-block:: yaml
 
-            - defaults.yaml
-            - Y:G@osarch
-            - Y:G@os_family
-            - Y:G@os
-            - Y:G@osfinger
+            - Y!P@defaults.yaml
+            - Y!G@osarch
+            - Y!G@os_family
+            - Y!G@os
+            - Y!G@osfinger
             - C@{tplroot}
-            - Y:G@id
+            - Y!G@id
 
         .. important::
             ``defaults.yaml`` is always prepended to the list, you don't need to include it.
@@ -149,6 +163,12 @@ def data(
         Whether to cache the result for subsequent calls with the same arguments.
         Can be overridden globally or per-formula.
         Enabled by default.
+
+    custom_data
+        .. versionadded:: 0.3.0
+
+        A custom dictionary that can provide values for the ``U`` matcher.
+        Must be picklable.
     """
     # Effectively, this function is a wrapper around stack that handles
     #   - retrieving stack configuration (matchers, defaults when merging)
@@ -169,6 +189,7 @@ def data(
         default_merge_strategy,
         default_merge_lists,
         post_map,
+        pickle.dumps(custom_data),
     )
 
     if cache and CKEY not in __context__:
@@ -196,10 +217,13 @@ def data(
             sources=["map_jinja.yaml"],
             default_values=default_formula_config,
             config_get_strategy=config_get_strategy,
-        )["values"]
+        )
 
-        if "defaults.yaml" not in map_config["sources"]:
-            map_config["sources"].insert(0, "defaults.yaml")
+        if not any(
+            defaults_repr in map_config["sources"]
+            for defaults_repr in ("defaults.yaml", "Y!defaults.yaml", "Y!P@defaults.yaml")
+        ):
+            map_config["sources"].insert(0, "Y!P@defaults.yaml")
 
         # Generate formula configuration based on the config above.
         formula_config = stack(
@@ -209,7 +233,7 @@ def data(
             default_merge_strategy=map_config["default_merge_strategy"],
             default_merge_lists=map_config["default_merge_lists"],
             config_get_strategy=map_config["config_get_strategy"],
-        )["values"]
+        )
 
         # Ensure mapdata allows to track the map_jinja configuration
         formula_config["map_jinja"] = map_config
@@ -241,6 +265,7 @@ def stack(
     default_merge_strategy=None,
     default_merge_lists=None,
     config_get_strategy=None,
+    custom_data=None,
 ):
     """
     Takes a list of matcher definitions and renders the resulting layered
@@ -275,80 +300,30 @@ def stack(
     config_get_strategy
         A ``merge`` strategy used in calls to :py:func:`config.get <salt.modules.config.get>`.
         Defaults to None.
+
+    custom_data
+        .. versionadded:: 0.3.0
+
+        A custom dictionary that can provide values for the ``U`` matcher.
     """
     tplroot = tpldir.split("/")[0]
     if parameter_dirs is None:
         parameter_dirs = [pdir.format(tplroot=tplroot) for pdir in DEFAULT_PARAM_DIRS_MAPSTACK]
-    res = {"values": default_values or {}}
-    if default_merge_strategy is not None:
-        res["merge_strategy"] = default_merge_strategy
-    if default_merge_lists is not None:
-        res["merge_lists"] = default_merge_lists
 
-    matchers = _render_matchers(sources, config_get_strategy=config_get_strategy)
-
-    for matcher in matchers:
-        if matcher["value"] is UNSET:
-            continue
-        if matcher["type"] in QUERY_MAP:
-            stack_config = ChainMap(matcher["value"], res)
-            strategy = traverse(stack_config, "strategy", default="smart")
-            merge_lists = traverse(stack_config, "merge_lists", default=False)
-            value = matcher["value"] or {}
-            if matcher["option"] == "SUB":
-                # Cut :lookup if we're subkeying the result.
-                # I'm unsure if this should be kept, need to look into the reasoning
-                # why it was done that way in the original mapstack implementation.
-                value = {
-                    (
-                        matcher["query"]
-                        if not matcher["query"].endswith(":lookup")
-                        else matcher["query"][:-7]
-                    ): value
-                }
-            res["values"] = merge(res["values"], value, strategy=strategy, merge_lists=merge_lists)
-        else:
-            # YAML via Y@
-            yaml_dirname = matcher["query"]
-            yaml_names = matcher["value"]
-            if matcher["value"] is ...:
-                # A static filename was specified.
-                file_path = Path(matcher["query"])
-                yaml_dirname, yaml_names = str(file_path.parent), [file_path.name]
-
-            all_yaml_names = []
-            for name in yaml_names:
-                file_ext = Path(name).suffix
-                if file_ext not in (".yaml", ".jinja"):
-                    all_yaml_names.extend((f"{name}.yaml", f"{name}.yaml.jinja"))
-                elif file_ext == ".yaml":
-                    all_yaml_names.extend((name, f"{name}.jinja"))
-                else:
-                    all_yaml_names.append(name)
-            for param_dir in parameter_dirs:
-                for yaml_name in all_yaml_names:
-                    yaml_path = Path(param_dir, yaml_dirname, yaml_name)
-                    yaml_cached = _get_template(
-                        yaml_path,
-                        tpldir=tpldir,
-                        tplroot=tplroot,
-                        mapdata=res["values"],
-                    )
-                    if not yaml_cached:
-                        continue
-                    with salt.utils.files.fopen(yaml_cached, "r") as ptr:
-                        yaml_values = salt.utils.yaml.safe_load(ptr)
-                    stack_config = ChainMap(yaml_values, res)
-                    strategy = traverse(stack_config, "strategy", default="smart")
-                    merge_lists = traverse(stack_config, "merge_lists", default=False)
-                    res["values"] = merge(
-                        res["values"],
-                        traverse(yaml_values, "values", default={}),
-                        strategy=strategy,
-                        merge_lists=merge_lists,
-                    )
-
-    return res
+    render_context = RenderContext(
+        stack=default_values or {},
+        tplroot=tplroot,
+        tpldir=tpldir,
+        base_dirs=parameter_dirs,
+        custom_data=custom_data,
+        config_get_strategy=config_get_strategy,
+        merge_strategy=default_merge_strategy,
+        merge_lists=default_merge_lists,
+    )
+    for matcher_chain in sources:
+        renderer = _render_matcher_chain(matcher_chain, render_context)
+        renderer.render()
+    return render_context.stack
 
 
 def tofs(
@@ -362,6 +337,7 @@ def tofs(
     files_dir="files",
     default_dir="default",
     config=None,
+    custom_data=None,
 ):
     """
     Render a list of TOFS patterns to be used as an input to states that
@@ -423,12 +399,17 @@ def tofs(
         If you have rendered the formula configuration, you can pass it here.
         If not passed, calls :py:func:`map.data <saltext.formula.modules.map.data`
         to fetch it.
+
+    custom_data
+        .. versionadded:: 0.3.0
+
+        A custom dictionary that can provide values for the ``U`` matcher.
     """
     tplroot = tpldir.split("/", maxsplit=1)[0]
     if config is None:
         config = data(tpldir)
     if default_matchers is None:
-        default_matchers = ("id", "os_family")
+        default_matchers = ("G@id", "G@os_family")
     if path_prefix is None:
         path_prefix = tplroot
 
@@ -438,9 +419,9 @@ def tofs(
     # for the `files_dir`.
     if use_subpath and tplroot != tpldir:
         for par in (Path(tpldir), *Path(tpldir).parents):
-            parent = "/".join(par.parts[1:])
+            parent = _concat_parts(par.parts[1:])
             if parent:
-                subpaths.append(f"/{parent}")
+                subpaths.append(parent)
     subpaths.append("")
 
     default_config = {
@@ -464,91 +445,483 @@ def tofs(
     include_query = tofs_config["include_query"]
 
     res = []
+    render_context = RenderContext(
+        stack=config,
+        tplroot=tplroot,
+        tpldir=tpldir,
+        base_dirs=[],
+        custom_data=custom_data,
+        config_get_strategy=config["map_jinja"]["config_get_strategy"],
+    )
+
     for subpath in subpaths:
-        override_path = "/".join(part for part in (subpath.strip("/"), "files_switch") if part)
+        override_path = _concat_parts(subpath, "files_switch")
         matchers = traverse(config, override_path, list(default_matchers), delimiter="/")
         if "" not in matchers:
             matchers.append("")
+        default_dir = str(traverse(tofs_config, "dirs:default", default_dir))
+        matchers = [matcher if matcher else f"P@{default_dir}" for matcher in matchers]
 
-        for matcher in matchers:
-            if matcher:
-                matcher_res = _render_matcher(
-                    matcher,
-                    config_get_strategy=config["map_jinja"]["config_get_strategy"],
-                    for_path_rendering=True,
-                )
-                matched_values = matcher_res["value"]
-                query = matcher_res["query"]
-                if matched_values is UNSET:
-                    matched_values = [matcher_res["query"]]
-                    query = ""
-            else:
-                matched_values = [str(traverse(tofs_config, "dirs:default", default_dir))]
-                query = ""
-
+        for matcher_chain in matchers:
+            renderer = _render_matcher_chain(matcher_chain, render_context, for_path_rendering=True)
+            results = renderer.render_path(
+                include_query=include_query,
+                base_dirs=[_concat_parts(base_prefix, subpath, files_dir)],
+                fallback_to_query=True,
+            )
             for src_file in source_files:
-                for matched_value in matched_values:
-                    url = "/".join(
-                        part.strip("/")
-                        for part in (
-                            base_prefix,
-                            subpath,
-                            files_dir,
-                            query if include_query else "",
-                            matched_value,
-                            src_file,
-                        )
-                        if part.strip("/")
-                    )
-                    res.append(f"salt://{url}")
+                for result in results:
+                    res.append(f"salt://{_concat_parts(result, src_file)}")
+
     return res
 
 
-def _render_matchers(matchers, *, config_get_strategy=None, for_path_rendering=False):
-    """
-    Normalize a list of matcher definitions and query their values.
+class SlotsReprTrait:
+    __slots__: tuple[str, ...] = ()
 
-    matchers
-        A list of matcher definitions.
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: {repr({slot: getattr(self, slot) for slot in self.__slots__})}"
 
-    config_get_strategy
-        When a ``config.get`` matcher (type ``C``) is specified,
-        override the default merge strategy.
 
-    for_path_rendering
-        Ensure returned query results can be used as path segments.
-        This means the YAML matcher (``Y``) is disabled and query
-        results are cast to a list of strings.
-        Defaults to false.
-    """
-    parsed_matchers = []
-    for matcher in matchers:
-        parsed_matchers.append(
-            _render_matcher(
-                matcher,
-                config_get_strategy=config_get_strategy,
-                for_path_rendering=for_path_rendering,
-            )
+class MatcherListResult(SlotsReprTrait):
+    __slots__ = ("query", "values")
+
+    query: str
+    values: Union[list[str], EllipsisType]
+
+    def __init__(
+        self,
+        query: str,
+        values: Any = ...,
+    ):
+        self.query = query
+        if values is ...:
+            pass
+        # Ensure we always return a list of string values when rendering paths
+        elif isinstance(values, str):
+            values = [values]
+        else:
+            try:
+                values = [str(name) for name in values]
+            except TypeError:
+                values = [str(values)]
+        self.values = values
+
+    def __bool__(self) -> bool:
+        return self.values is not ...
+
+
+class MatcherResult(SlotsReprTrait):
+    __slots__ = ("query", "values", "merge_strategy", "merge_lists")
+
+    query: str
+    values: Union[dict[Any, Any], EllipsisType]
+    merge_strategy: Optional[str]
+    merge_lists: Optional[bool]
+
+    def __init__(
+        self,
+        query: str,
+        values: Union[dict[Any, Any], EllipsisType] = ...,
+        strategy: Optional[str] = None,
+        merge_lists: Optional[bool] = None,
+    ):
+        self.query = query
+        self.values = values
+        self.merge_strategy = strategy
+        self.merge_lists = merge_lists
+
+    def __bool__(self) -> bool:
+        return self.values is not ...
+
+    @classmethod
+    def from_bare(cls, query, bare):
+        try:
+            merge_strategy = bare.pop("strategy", None)
+            merge_lists = bare.pop("merge_lists", None)
+        except (AttributeError, TypeError):
+            merge_strategy = merge_lists = None
+        return cls(query=query, values=bare, strategy=merge_strategy, merge_lists=merge_lists)
+
+
+class RenderContext(SlotsReprTrait):
+    __slots__ = (
+        "stack",
+        "base_dirs",
+        "custom_data",
+        "tpldir",
+        "tplroot",
+        "config_get_strategy",
+        "merge_strategy",
+        "merge_lists",
+    )
+
+    stack: dict
+    base_dirs: tuple[str, ...]
+    custom_data: dict[str, Union[list[str], dict]]
+    tpldir: str
+    tplroot: str
+    config_get_strategy: Optional[str]
+    merge_strategy: str
+    merge_lists: bool
+
+    def __init__(
+        self,
+        stack: dict,  # pylint: disable = redefined-outer-name
+        base_dirs: tuple[str, ...],
+        tpldir: str,
+        tplroot: str,
+        custom_data: Optional[dict[str, Union[list[str], dict]]] = None,
+        config_get_strategy: Optional[str] = None,
+        merge_strategy: Optional[str] = "smart",
+        merge_lists: Optional[bool] = False,
+    ):
+        self.stack = stack
+        self.base_dirs = tuple(base_dirs)
+        self.tpldir = tpldir
+        self.tplroot = tplroot
+        self.custom_data = custom_data or {}
+        self.config_get_strategy = config_get_strategy
+        self.merge_strategy = merge_strategy or "smart"
+        self.merge_lists = merge_lists if merge_lists is not None else False
+
+    def merge_result(self, result: MatcherResult) -> None:
+        if not result:  # pragma: no cover
+            return
+        strategy = (
+            result.merge_strategy if result.merge_strategy is not None else self.merge_strategy
+        )
+        merge_lists = result.merge_lists if result.merge_lists is not None else self.merge_lists
+        self.stack = merge(
+            self.stack,
+            result.values,
+            strategy=strategy,
+            merge_lists=merge_lists,
         )
 
-    return parsed_matchers
+
+class Matcher(SlotsReprTrait):
+    __slots__ = ("query", "options", "delimiter")
+
+    query: str
+    options: tuple[str, ...]
+    delimiter: str
+
+    def __init__(
+        self, query: str, options: Sequence[str] = (), delimiter: Optional[str] = ":", **_
+    ):
+        self.query = query
+        self.delimiter = delimiter or ":"
+        if not options or options == ("",):
+            self.options = ()
+        else:
+            self.options = tuple(options) if not isinstance(options, str) else (options,)
+
+    def value(self, **kwargs) -> MatcherResult:
+        res = self._fetch(**kwargs)
+        if not res:
+            return res
+        if "SUB" in self.options:
+            if self.query.endswith(f"{self.delimiter}lookup"):
+                res.values = {self.query[:-7]: res.values}
+            else:
+                res.values = {self.query: res.values}
+        return res
+
+    def value_list(self, **kwargs) -> MatcherListResult:
+        res = self._fetch(**kwargs)
+        return MatcherListResult(query=res.query, values=res.values)
+
+    def _fetch(self, **_):
+        raise NotImplementedError
 
 
-def _render_matcher(matcher, *, config_get_strategy=None, for_path_rendering=False):
+class ConfigMatcher(Matcher):
+    __slots__ = ("_config_get",)
+
+    _config_get: Callable
+
+    def __init__(self, *args, __salt__, **kwargs):
+        super().__init__(*args, __salt__=__salt__, **kwargs)
+        # This is used in the wrapper as well, where the methods
+        # don't have access to the loader dunders.
+        self._config_get = __salt__["config.get"]
+
+    def _fetch(self, *, render_context, **_):  # pylint: disable=arguments-differ
+        values = self._config_get(
+            self.query, ..., merge=render_context.config_get_strategy, delimiter=self.delimiter
+        )
+        return MatcherResult.from_bare(self.query, values)
+
+
+class GrainsMatcher(Matcher):
+    __slots__ = ("_grains_get",)
+
+    _grains_get: Callable
+
+    def __init__(self, *args, __salt__, **kwargs):
+        super().__init__(*args, __salt__=__salt__, **kwargs)
+        # This is used in the wrapper as well, where the methods
+        # don't have access to the loader dunders.
+        self._grains_get = __salt__["grains.get"]
+
+    def _fetch(self, **_):
+        values = self._grains_get(self.query, ..., delimiter=self.delimiter)
+        return MatcherResult.from_bare(self.query, values)
+
+
+class PillarMatcher(Matcher):
+    __slots__ = ("_pillar_get",)
+
+    _pillar_get: Callable
+
+    def __init__(self, *args, __salt__, **kwargs):
+        super().__init__(*args, __salt__=__salt__, **kwargs)
+        # This is used in the wrapper as well, where the methods
+        # don't have access to the loader dunders.
+        self._pillar_get = __salt__["pillar.get"]
+
+    def _fetch(self, **_):
+        values = self._pillar_get(self.query, ..., delimiter=self.delimiter)
+        return MatcherResult.from_bare(self.query, values)
+
+
+class MapdataMatcher(Matcher):
+    def _fetch(self, *, render_context, **_):  # pylint: disable=arguments-differ
+        values = traverse(render_context.stack, self.query, ..., delimiter=self.delimiter)
+        return MatcherResult.from_bare(self.query, values)
+
+
+class CustomMatcher(Matcher):
+    def _fetch(self, *, render_context, **_):  # pylint: disable=arguments-differ
+        values = traverse(render_context.custom_data, self.query, ..., delimiter=self.delimiter)
+        return MatcherResult.from_bare(self.query, values)
+
+
+class StaticMatcher(Matcher):
+    def value(self, **kwargs):
+        raise NotImplementedError("The StaticMatcher cannot be used for querying data")
+
+    def value_list(self, **kwargs):
+        return MatcherListResult(query="", values=[self.query])
+
+    def is_file_name(self):
+        return Path(self.query).suffix != ""
+
+
+class Renderer(SlotsReprTrait):
+    __slots__ = ("_matchers", "render_context", "chain_finished")
+
+    _matchers: list[Matcher]
+    render_context: RenderContext
+    chain_finished: bool
+
+    def __init__(self, render_context: RenderContext):
+        self.render_context = render_context
+        self._matchers = []
+        self.chain_finished = False
+
+    def add_matcher(self, matcher: Matcher) -> None:
+        if self.chain_finished:
+            raise ValueError(
+                f"Cannot append other matchers after `{self._matchers[-1]}`: {matcher}"
+            )
+        try:
+            if matcher.is_file_name():  # type: ignore
+                self.chain_finished = True
+        except AttributeError:
+            pass
+
+        self._matchers.append(matcher)
+
+    def render(self) -> RenderContext:
+        res = None
+        default_merge_strategy = merge_strategy = self.render_context.merge_strategy
+        default_merge_lists = merge_lists = self.render_context.merge_lists
+
+        for matcher in self._matchers:
+            if res is None:
+                res = matcher.value(render_context=self.render_context)
+                if not res:
+                    return self.render_context
+                merge_strategy = (
+                    res.merge_strategy if res.merge_strategy is not None else default_merge_strategy
+                )
+                merge_lists = (
+                    res.merge_lists if res.merge_lists is not None else default_merge_lists
+                )
+                continue
+            intermittent = {}
+            metadata = matcher.value_list(render_context=self.render_context)
+            if not metadata:
+                return {}
+            for lookup in metadata.values:
+                intermittent = merge(
+                    intermittent,
+                    traverse(res.values, lookup, {}),
+                    strategy=merge_strategy,
+                    merge_lists=merge_lists,
+                )
+            res.values = intermittent
+
+        self.render_context.merge_result(res)  # type: ignore
+        return self.render_context
+
+    def render_path(
+        self,
+        include_query: bool = True,
+        base_dirs: Optional[list[str]] = None,
+        fallback_to_query: bool = False,
+    ) -> list[str]:
+        relative_parts = []
+        for matcher in self._matchers:
+            res = matcher.value_list(render_context=self.render_context)
+            if not res:
+                if not fallback_to_query:
+                    return []
+                relative_parts.append([res.query])
+            elif include_query:
+                relative_parts.append([_concat_parts(res.query, r) for r in res.values])  # type: ignore
+            else:
+                relative_parts.append(res.values)  # type: ignore
+        relative_paths = [_concat_parts(rel) for rel in itertools.product(*relative_parts)]
+        absolute_paths = [
+            _concat_parts(absolute)
+            for absolute in itertools.product(
+                base_dirs or self.render_context.base_dirs, relative_paths
+            )
+        ]
+        return absolute_paths
+
+
+class YAMLRenderer(Renderer):
+    __slots__ = ("_get_template",)
+
+    _get_template: Callable
+
+    def __init__(self, render_context: RenderContext, _get_template: Callable):
+        super().__init__(render_context)
+        self._get_template = _get_template
+
+    def render(self) -> RenderContext:
+        for path in self.render_path():
+            for yaml_result in self._load_yaml(path):
+                self.render_context.merge_result(yaml_result)
+
+        return self.render_context
+
+    def _load_yaml(self, path: str):
+        file_ext = Path(path).suffix
+        ext_paths: list[str] = []
+        if file_ext not in (".yaml", ".jinja"):
+            ext_paths.extend((f"{path}.yaml", f"{path}.yaml.jinja"))
+        elif file_ext == ".yaml":
+            ext_paths.extend((path, f"{path}.jinja"))
+        else:
+            ext_paths.append(path)
+        res = []
+        for ext_path in ext_paths:
+            yaml_cached = self._get_template(
+                ext_path,
+                tpldir=self.render_context.tpldir,
+                tplroot=self.render_context.tplroot,
+                mapdata=self.render_context.stack,
+                custom_data=self.render_context.custom_data,
+            )
+            if not yaml_cached:
+                continue
+            with salt.utils.files.fopen(yaml_cached, "r") as ptr:
+                yaml_values = salt.utils.yaml.safe_load(ptr)
+            try:
+                res.append(MatcherResult(**yaml_values, query=""))
+            except TypeError as err:
+                raise TypeError(f"Got invalid data from salt://{ext_path}: {err}") from err
+
+        return res
+
+
+def _concat_parts(*parts: Union[str, Iterable[str]]) -> str:
+    # We don't want to account for the OS-specific path separator
+    return "/".join(
+        chain.from_iterable(
+            (
+                (ppart.strip("/") for ppart in part if ppart)
+                if isinstance(part, Iterable) and not isinstance(part, str)
+                else [part.strip("/")]
+            )
+            for part in parts
+            if part
+        )
+    )
+
+
+TYP_CLS_MAP: dict[str, type[Matcher]] = {
+    "G": GrainsMatcher,
+    "I": PillarMatcher,
+    "C": ConfigMatcher,
+    "M": MapdataMatcher,
+    "U": CustomMatcher,
+    "P": StaticMatcher,
+}
+
+
+def _render_matcher_chain(
+    mchain: str, render_context: RenderContext, for_path_rendering: bool = False
+) -> Renderer:
     """
-    Normalize a matcher definition and execute the query.
+    Parse a [chain of] matcher definitions into a Renderer, which can be used
+    to render the result.
 
-    matcher
-        A matcher definition.
+    .. note::
+        In the context of mapstack/tofs configuration, this parses a single item
+        of ``sources``/``files_switch``, which are allowed to contain a series
+        of matchers.
 
-    config_get_strategy
-        When a ``config.get`` matcher (type ``C``) is specified,
-        override the default merge strategy.
+    mchain
+        A matcher definition, which can contain a chain of multiple single ones.
+
+    render_context
+        A RenderContext instance providing data necessary for rendering.
 
     for_path_rendering
-        Ensure returned query results can be used as path segments.
-        This means the YAML matcher (``Y``) is disabled and query
-        results are cast to a list of strings.
+        Disable YAML file loading and use different defaults when no matcher is specified.
+        [Given ``os``; false: ``Y!C@os``; true: ``C@os``]
+        Defaults to false.
+    """
+    yaml_renderer = mchain.startswith("Y!")
+    if yaml_renderer:
+        if for_path_rendering:
+            raise ValueError(f"Cannot use YAML renderer for path rendering: {mchain}")
+        mchain = mchain[2:]
+
+    matcher_chain = mchain.split("|")
+    initial_matcher, is_yaml = _render_matcher(
+        matcher_chain[0], for_path_rendering=for_path_rendering
+    )
+    if yaml_renderer or is_yaml:
+        renderer: Renderer = YAMLRenderer(render_context, _get_template)
+    else:
+        renderer = Renderer(render_context)
+    renderer.add_matcher(initial_matcher)
+    for single in matcher_chain[1:]:
+        matcher, is_yaml = _render_matcher(single, for_path_rendering=for_path_rendering)
+        if is_yaml:
+            raise ValueError(f"Cannot use YAML matcher in query chains: `{chain}`")
+        renderer.add_matcher(matcher)
+    return renderer
+
+
+def _render_matcher(matcher: str, for_path_rendering=False) -> tuple[Matcher, bool]:
+    """
+    Parse a single matcher definition into a Matcher and indicate whether its
+    result should be parsed by loading a YAML file or directly.
+
+    matcher
+        A matcher definition for a single matcher.
+
+    for_path_rendering
+        Disable YAML file loading and use different defaults when no matcher is specified.
+        [Given ``os``; false: ``Y!C@os``; true: ``C@os``]
         Defaults to false.
     """
     query, *key = matcher.split("@")
@@ -557,57 +930,28 @@ def _render_matcher(matcher, *, config_get_strategy=None, for_path_rendering=Fal
         if rest and rest[0] == "":
             # colon as delimiter was explicitly specified via Y:C::@roles
             delimiter = ":"
-        if typ == "Y" and for_path_rendering:
-            raise ValueError(f"YAML type is not allowed in this context. Got: {matcher}")
-        parsed = {
-            "type": typ,
-            "option": option or ("C" if typ == "Y" else None),
-            "query_delimiter": delimiter or ":",
-            "query": key[0],
-        }
-    elif query.endswith((".yaml", ".jinja")):
+        if typ == "Y":
+            if for_path_rendering:
+                raise ValueError(f"YAML type is not allowed in this context. Got: {matcher}")
+            subtyp = option or "C"
+            return TYP_CLS_MAP[subtyp](query=key[0], delimiter=delimiter, __salt__=__salt__), True
+
+        return (
+            TYP_CLS_MAP[typ](  # type: ignore
+                query=key[0],
+                options=tuple((option or "").split(",")),
+                delimiter=delimiter,
+                __salt__=__salt__,
+            ),
+            False,
+        )
+    if query.endswith((".yaml", ".jinja")):
         if for_path_rendering:
             raise ValueError(f"YAML type is not allowed in this context. Got: {matcher}")
         # Static file path like defaults.yaml
-        parsed = {
-            "type": "Y",
-            "option": None,
-            "query_delimiter": None,
-            "query_method": None,
-            "query": query,
-            "value": ...,
-        }
-    else:
-        # Configuration without @, example: mysql.
-        # Interpret it as a YAML source with config.get query.
-        parsed = {
-            "type": "Y" if not for_path_rendering else "C",
-            "option": "C" if not for_path_rendering else None,
-            "query_delimiter": ":",
-            "query": query,
-        }
-
-    if "query_method" not in parsed:
-        parsed["query_method"] = QUERY_MAP.get(parsed["type"]) or QUERY_MAP[parsed["option"]]
-    query_opts = {"delimiter": parsed["query_delimiter"]}
-    if parsed["query_method"] == "config.get" and config_get_strategy:
-        query_opts["merge"] = config_get_strategy
-    if "value" not in parsed:
-        query_result = __salt__[parsed["query_method"]](
-            parsed["query"], default=UNSET, **query_opts
-        )
-        if query_result is not UNSET and (parsed["type"] == "Y" or for_path_rendering):
-            # Ensure we always return a list of string values when rendering paths
-            if isinstance(query_result, str):
-                query_result = [query_result]
-            else:
-                try:
-                    query_result = [str(name) for name in query_result]
-                except TypeError:
-                    query_result = [str(query_result)]
-        parsed["value"] = query_result
-
-    return parsed
+        return StaticMatcher(query=query, options=()), True
+    # Configuration without @, example: mysql.
+    return TYP_CLS_MAP["C"](query=query, __salt__=__salt__), not for_path_rendering
 
 
 def _get_template(path, **kwargs):

--- a/src/saltext/formula/wrapper/map.py
+++ b/src/saltext/formula/wrapper/map.py
@@ -11,8 +11,9 @@ import logging
 
 from salt.utils.functools import namespaced_function
 
+from saltext.formula.modules.map import _concat_parts as _concat_parts_base
 from saltext.formula.modules.map import _render_matcher as _render_matcher_base
-from saltext.formula.modules.map import _render_matchers as _render_matchers_base
+from saltext.formula.modules.map import _render_matcher_chain as _render_matcher_chain_base
 from saltext.formula.modules.map import data
 from saltext.formula.modules.map import stack
 from saltext.formula.modules.map import tofs
@@ -29,13 +30,15 @@ def __virtual__():
 data = namespaced_function(data, globals())
 stack = namespaced_function(stack, globals())
 tofs = namespaced_function(tofs, globals())
+_concat_parts = namespaced_function(_concat_parts_base, globals())
 _render_matcher = namespaced_function(_render_matcher_base, globals())
-_render_matchers = namespaced_function(_render_matchers_base, globals())
+_render_matcher_chain = namespaced_function(_render_matcher_chain_base, globals())
 
 
 for func, base in (
+    (_concat_parts, _concat_parts_base),
     (_render_matcher, _render_matcher_base),
-    (_render_matchers, _render_matchers_base),
+    (_render_matcher_chain, _render_matcher_chain_base),
 ):
     # namespaced_function does not initialize keyword-only argument defaults,
     # making them required arguments.

--- a/tests/unit/modules/test_map.py
+++ b/tests/unit/modules/test_map.py
@@ -75,130 +75,280 @@ def configure_loader_modules(opts, grains, pillar, context, cp_get_template):
 
 
 @pytest.mark.parametrize(
-    "matcher,expected",
+    "matcher,cls,exp_yaml,attrs,value",
     (
         (
             "roles_opts",
+            map_mod.ConfigMatcher,
+            True,
             {
-                "query_method": "config.get",
                 "query": "roles_opts",
-                "value": ["opts_role_a", "opts_role_b"],
+                "options": (),
+                "delimiter": ":",
             },
+            ["opts_role_a", "opts_role_b"],
         ),
         (
             "C@tplroot_opts",
-            {"query_method": "config.get", "query": "tplroot_opts", "value": {"config": "data"}},
+            map_mod.ConfigMatcher,
+            False,
+            {"query": "tplroot_opts", "options": (), "delimiter": ":"},
+            {"config": "data"},
         ),
         (
             "C@nested:opts:config",
-            {"query_method": "config.get", "query": "nested:opts:config", "value": {"data": True}},
+            map_mod.ConfigMatcher,
+            False,
+            {"query": "nested:opts:config", "options": (), "delimiter": ":"},
+            {"data": True},
         ),
         (
             "C:::@nested:opts:config",
-            {"query_method": "config.get", "query": "nested:opts:config", "value": {"data": True}},
+            map_mod.ConfigMatcher,
+            False,
+            {"query": "nested:opts:config", "options": (), "delimiter": ":"},
+            {"data": True},
         ),
         (
             "C:SUB@nested:opts:config",
-            {
-                "query_method": "config.get",
-                "query": "nested:opts:config",
-                "value": {"data": True},
-                "option": "SUB",
-            },
+            map_mod.ConfigMatcher,
+            False,
+            {"query": "nested:opts:config", "options": ("SUB",), "delimiter": ":"},
+            {"nested:opts:config": {"data": True}},
         ),
         (
             "C:SUB:!@nested!opts!config",
-            {
-                "query_method": "config.get",
-                "query": "nested!opts!config",
-                "value": {"data": True},
-                "option": "SUB",
-            },
+            map_mod.ConfigMatcher,
+            False,
+            {"query": "nested!opts!config", "options": ("SUB",), "delimiter": "!"},
+            {"nested!opts!config": {"data": True}},
         ),
         (
             "C:SUB::@nested:opts:config",
-            {
-                "query_method": "config.get",
-                "query": "nested:opts:config",
-                "value": {"data": True},
-                "option": "SUB",
-            },
+            map_mod.ConfigMatcher,
+            False,
+            {"query": "nested:opts:config", "options": ("SUB",), "delimiter": ":"},
+            {"nested:opts:config": {"data": True}},
         ),
         (
             "G@tplroot_grains",
-            {"query_method": "grains.get", "query": "tplroot_grains", "value": {"config": "data"}},
+            map_mod.GrainsMatcher,
+            False,
+            {"query": "tplroot_grains", "options": (), "delimiter": ":"},
+            {"config": "data"},
         ),
         (
             "I@tplroot_pillar",
-            {"query_method": "pillar.get", "query": "tplroot_pillar", "value": {"config": "data"}},
+            map_mod.PillarMatcher,
+            False,
+            {"query": "tplroot_pillar", "options": (), "delimiter": ":"},
+            {"config": "data"},
         ),
-        ("defaults.yaml", {"query_method": None, "query": "defaults.yaml", "value": ...}),
+        (
+            "defaults.yaml",
+            map_mod.StaticMatcher,
+            True,
+            {"query": "defaults.yaml", "options": (), "delimiter": ":"},
+            ["defaults.yaml"],
+        ),
         (
             "Y@roles_opts",
+            map_mod.ConfigMatcher,
+            True,
             {
-                "query_method": "config.get",
                 "query": "roles_opts",
-                "value": ["opts_role_a", "opts_role_b"],
+                "options": (),
+                "delimiter": ":",
             },
+            ["opts_role_a", "opts_role_b"],
         ),
         (
             "Y:C@roles_opts",
+            map_mod.ConfigMatcher,
+            True,
             {
-                "query_method": "config.get",
                 "query": "roles_opts",
-                "value": ["opts_role_a", "opts_role_b"],
+                "options": (),
+                "delimiter": ":",
             },
+            ["opts_role_a", "opts_role_b"],
         ),
         (
             "Y:I@roles_pillar",
+            map_mod.PillarMatcher,
+            True,
             {
-                "query_method": "pillar.get",
                 "query": "roles_pillar",
-                "value": ["pillar_role_a", "pillar_role_b"],
+                "options": (),
+                "delimiter": ":",
             },
+            ["pillar_role_a", "pillar_role_b"],
         ),
         (
             "Y:G@roles_grain",
+            map_mod.GrainsMatcher,
+            True,
             {
-                "query_method": "grains.get",
                 "query": "roles_grain",
-                "value": ["grain_role_a", "grain_role_b"],
+                "options": (),
+                "delimiter": ":",
             },
+            ["grain_role_a", "grain_role_b"],
         ),
-        ("Y:G@os", {"query_method": "grains.get", "query": "os", "value": ["Fedora"]}),
+        (
+            "Y:G@os",
+            map_mod.GrainsMatcher,
+            True,
+            {
+                "query": "os",
+                "options": (),
+                "delimiter": ":",
+            },
+            ["Fedora"],
+        ),
         (
             "Y:G@selinux:enabled",
-            {"query_method": "grains.get", "query": "selinux:enabled", "value": ["True"]},
+            map_mod.GrainsMatcher,
+            True,
+            {
+                "query": "selinux:enabled",
+                "options": (),
+                "delimiter": ":",
+            },
+            ["True"],
         ),
         (
             "Y:G::@selinux:enabled",
-            {"query_method": "grains.get", "query": "selinux:enabled", "value": ["True"]},
+            map_mod.GrainsMatcher,
+            True,
+            {
+                "query": "selinux:enabled",
+                "options": (),
+                "delimiter": ":",
+            },
+            ["True"],
         ),
         (
             "Y:G:!@selinux!enabled",
-            {"query_method": "grains.get", "query": "selinux!enabled", "value": ["True"]},
+            map_mod.GrainsMatcher,
+            True,
+            {
+                "query": "selinux!enabled",
+                "options": (),
+                "delimiter": "!",
+            },
+            ["True"],
         ),
         (
             "C@nonexistent",
-            {"query_method": "config.get", "query": "nonexistent", "value": map_mod.UNSET},
+            map_mod.ConfigMatcher,
+            False,
+            {
+                "query": "nonexistent",
+                "options": (),
+                "delimiter": ":",
+            },
+            ...,
         ),
         (
             "I@nonexistent",
-            {"query_method": "pillar.get", "query": "nonexistent", "value": map_mod.UNSET},
+            map_mod.PillarMatcher,
+            False,
+            {
+                "query": "nonexistent",
+                "options": (),
+                "delimiter": ":",
+            },
+            ...,
         ),
         (
             "G@nonexistent",
-            {"query_method": "grains.get", "query": "nonexistent", "value": map_mod.UNSET},
+            map_mod.GrainsMatcher,
+            False,
+            {
+                "query": "nonexistent",
+                "options": (),
+                "delimiter": ":",
+            },
+            ...,
+        ),
+        (
+            "Y:G@nonexistent",
+            map_mod.GrainsMatcher,
+            True,
+            {
+                "query": "nonexistent",
+                "options": (),
+                "delimiter": ":",
+            },
+            ...,
+        ),
+        (
+            "P@defaults.yaml",
+            map_mod.StaticMatcher,
+            False,
+            {
+                "query": "defaults.yaml",
+                "options": (),
+                "delimiter": ":",
+            },
+            ["defaults.yaml"],
+        ),
+        (
+            "Y:M@variant",
+            map_mod.MapdataMatcher,
+            True,
+            {
+                "query": "variant",
+                "options": (),
+                "delimiter": ":",
+            },
+            ["foo"],
+        ),
+        (
+            "Y:U@users",
+            map_mod.CustomMatcher,
+            True,
+            {
+                "query": "users",
+                "options": (),
+                "delimiter": ":",
+            },
+            ["testuser"],
+        ),
+        (
+            "Y:U@users_str",
+            map_mod.CustomMatcher,
+            True,
+            {
+                "query": "users_str",
+                "options": (),
+                "delimiter": ":",
+            },
+            ["testuser"],
         ),
     ),
 )
-def test_render_matcher(matcher, expected):
-    res = map_mod._render_matcher(matcher)
-    for param, val in expected.items():
-        if param == "value" and val is map_mod.UNSET:
-            assert res[param] is val
-        else:
-            assert res[param] == val
+def test_render_matcher(matcher, cls, exp_yaml, attrs, value):
+    render_context = map_mod.RenderContext(
+        stack={"variant": "foo"},
+        base_dirs=["tplroot/parameters"],
+        tpldir="tplroot/foo/bar",
+        tplroot="tplroot",
+        custom_data={"users": ["testuser"], "users_str": "testuser"},
+    )
+    res, is_yaml = map_mod._render_matcher(matcher)
+    assert res.__class__ is cls
+    assert is_yaml is exp_yaml
+    for attr, val in attrs.items():
+        assert getattr(res, attr) == val
+    if exp_yaml:
+        assert res.value_list(render_context=render_context).values == value
+    else:
+        try:
+            assert res.value(render_context=render_context).values == value
+        except NotImplementedError:
+            assert res.value_list(render_context=render_context).values == value
 
 
 @pytest.mark.parametrize(
@@ -211,17 +361,79 @@ def test_render_matcher(matcher, expected):
     ),
 )
 def test_render_matcher_for_path_rendering(matcher, expected):
-    res = map_mod._render_matcher(matcher, for_path_rendering=True)
-    assert res["query_method"] == "config.get"
-    assert res["type"] == "C"
-    assert res["query"] == matcher.split("@")[-1]
-    assert res["value"] == expected
+    render_context = map_mod.RenderContext(
+        stack={},
+        base_dirs=["tplroot/parameters"],
+        tpldir="tplroot/foo/bar",
+        tplroot="tplroot",
+    )
+    res, is_yaml = map_mod._render_matcher(matcher, for_path_rendering=True)
+    assert is_yaml is False
+    assert res.__class__ is map_mod.ConfigMatcher
+    assert res.query == matcher.split("@")[-1]
+    assert res.value_list(render_context=render_context).values == expected
 
 
 @pytest.mark.parametrize("matcher", ("defaults.yaml", "Y:C@roles_opts"))
 def test_render_matcher_for_path_rendering_yaml_disallowed(matcher):
     with pytest.raises(ValueError, match=f".*not allowed in this context.*{matcher}$"):
         map_mod._render_matcher(matcher, for_path_rendering=True)
+
+
+@pytest.mark.parametrize(
+    "chain,typ,matchers",
+    (
+        (
+            "Y!G@os|C@roles_opts",
+            map_mod.YAMLRenderer,
+            [
+                map_mod.GrainsMatcher(query="os", __salt__={"grains.get": grains_mod.get}),
+                map_mod.ConfigMatcher(query="roles_opts", __salt__={"config.get": config_mod.get}),
+            ],
+        ),
+        (
+            "Y!roles",
+            map_mod.YAMLRenderer,
+            [map_mod.ConfigMatcher(query="roles", __salt__={"config.get": config_mod.get})],
+        ),
+    ),
+)
+def test_render_matcher_chain(chain, typ, matchers):
+    render_context = map_mod.RenderContext(
+        stack={"variant": "foo"},
+        base_dirs=["tplroot/parameters"],
+        tpldir="tplroot/foo/bar",
+        tplroot="tplroot",
+        custom_data={"users": ["testuser"], "users_str": "testuser"},
+    )
+    renderer = map_mod._render_matcher_chain(chain, render_context)
+    assert isinstance(renderer, typ)
+    assert len(renderer._matchers) == len(matchers)
+    for actual_matcher, expected_matcher in zip(renderer._matchers, matchers):
+        assert isinstance(actual_matcher, type(expected_matcher))
+        for slot in expected_matcher.__slots__:
+            if slot.startswith("_"):
+                continue
+            assert getattr(actual_matcher, slot) == getattr(expected_matcher, slot)
+
+
+@pytest.mark.parametrize(
+    "chain,for_path_rendering,msg",
+    (
+        ("variant_defaults.yaml|M@variant", False, "Cannot append other matchers after.*"),
+        ("os|variant_defaults.yaml|M@variant", False, "Cannot use YAML matcher in query chains.*"),
+        ("Y!G@os|C@roles_opts", True, "Cannot use YAML renderer for path rendering.*"),
+    ),
+)
+def test_render_matcher_chain_disallowed(chain, for_path_rendering, msg):
+    render_context = map_mod.RenderContext(
+        stack={},
+        base_dirs=["tplroot/parameters"],
+        tpldir="tplroot/foo/bar",
+        tplroot="tplroot",
+    )
+    with pytest.raises(ValueError, match=msg):
+        map_mod._render_matcher_chain(chain, render_context, for_path_rendering=for_path_rendering)
 
 
 def test_data_configuration_override(context, cp_get_template):
@@ -239,7 +451,7 @@ def test_data_configuration_override(context, cp_get_template):
         "cache": False,
     }
     with patch("saltext.formula.modules.map.stack", autospec=True) as stack:
-        stack.side_effect = ({"values": default_formula_config}, {"values": {}})
+        stack.side_effect = (default_formula_config, {})
         res = map_mod.data("tplroot/foo/bar", config_get_strategy="foobar")
 
     assert res == {"map_jinja": default_formula_config}
@@ -264,7 +476,7 @@ def test_data_configuration_override(context, cp_get_template):
 @pytest.fixture
 def stack_mock():
     def _stack(*args, default_values=None, **kwargs):  # pylint: disable=unused-argument
-        return {"values": default_values or {}}
+        return default_values or {}
 
     with patch("saltext.formula.modules.map.stack", autospec=True, side_effect=_stack) as stack:
         yield stack
@@ -568,6 +780,22 @@ def test_data_no_duplicate_defaults_yaml():
                 "tplroot/files/default/foo.jinja",
             ],
         ),
+        (
+            ["G@os_family|I@roles_pillar|P@foo/bar/baz"],
+            None,
+            None,
+            None,
+            False,
+            True,
+            [
+                "tplroot/files/os_family/RedHat/roles_pillar/pillar_role_a/foo/bar/baz/foo",
+                "tplroot/files/os_family/RedHat/roles_pillar/pillar_role_b/foo/bar/baz/foo",
+                "tplroot/files/os_family/RedHat/roles_pillar/pillar_role_a/foo/bar/baz/foo.jinja",
+                "tplroot/files/os_family/RedHat/roles_pillar/pillar_role_b/foo/bar/baz/foo.jinja",
+                "tplroot/files/default/foo",
+                "tplroot/files/default/foo.jinja",
+            ],
+        ),
     ),
 )
 def test_tofs(matchers, path_prefix, files_dir, default_dir, use_subpath, include_query, expected):
@@ -680,7 +908,7 @@ def test_tofs_override(overrides, expected):
     assert res == expected
 
 
-def test_subpath_matcher_override():
+def test_tofs_subpath_matcher_override():
     config = {
         "tofs": {
             "files_switch": ["id"],


### PR DESCRIPTION
### What does this PR do?
* add M/P/U matchers
* introduce chains
* deprecate `Y:` matcher in favor of `Y!` prefix indicating to load the results as YAML files

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
* Only single matchers per data source
* No matchers based on mapdata or custom data
* Only implicit static file declaration

### New Behavior
* Multiple matchers can be chained
* `M@` (mapdata) and `U@` (custom data passed as `custom_data`) matchers are available
* `P@` matcher declares static paths

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes